### PR TITLE
Bump version to make the Flatpak update actually be published

### DIFF
--- a/one.ablaze.floorp.appdata.xml
+++ b/one.ablaze.floorp.appdata.xml
@@ -56,6 +56,7 @@
   </screenshots>
   <content_rating type="oars-1.1"></content_rating>
   <releases>
+    <release version="11.11.1.1" date="2024-03-21"></release>
     <release version="11.11.1" date="2024-03-21"></release>
     <release version="11.11.0" date="2024-03-19"></release>
     <release version="11.10.5" date="2024-02-26"></release>


### PR DESCRIPTION
Tried manual build, vanished outta thin air - seems this is the only other means of making this update actually get pushed after Flathub API went down last version. 