### PR TITLE
Revert: Change license to Proprietary

### DIFF
--- a/one.ablaze.floorp.appdata.xml
+++ b/one.ablaze.floorp.appdata.xml
@@ -2,7 +2,7 @@
 <component type="desktop-application">
   <id>one.ablaze.floorp</id>
   <metadata_license>CC0-1.0</metadata_license>
-  <project_license>LicenseRef-proprietary=https://raw.githubusercontent.com/Floorp-Projects/About-Floorp-Projects/main/UserLicense.md</project_license>
+  <project_license>MPL-2.0</project_license>
   <name>Floorp</name>
   <summary>A Firefox-based, flexible browser developed in Japan with a variety of features.</summary>
   <developer_name>Ablaze</developer_name>
@@ -16,6 +16,7 @@
       <li>Switchable Design</li>
       <li>Regular Updates</li>
       <li>No User Tracking</li>
+      <li>Powered by Open Source</li>
     </ul>
   </description>
   <branding>


### PR DESCRIPTION
The closed source portions of Floorp are no longer used, meaning Floorp's least permissive license is now MPL-2.0, thus open source, once more.

CLOSES #80 