### PR TITLE
Set `security.sandbox.warn_unprivileged_namespaces` to `false`

### DIFF
--- a/one.ablaze.floorp.appdata.xml
+++ b/one.ablaze.floorp.appdata.xml
@@ -56,6 +56,9 @@
   </screenshots>
   <content_rating type="oars-1.1"/>
   <releases>
+    <release version="11.17.6.1" date="2024-08-22">
+      <description></description>
+    </release>
     <release version="11.17.6" date="2024-08-22">
       <description></description>
     </release>

--- a/src/lib/floorp/defaults/pref/flatpak-prefs.js
+++ b/src/lib/floorp/defaults/pref/flatpak-prefs.js
@@ -5,3 +5,5 @@ pref("enable.floorp.update", false);
 pref("enable.floorp.updater.latest", false);
 
 pref("accessibility.typeaheadfind.soundURL", "default");
+
+pref("security.sandbox.warn_unprivileged_namespaces", false);


### PR DESCRIPTION
Temporary fix for bug 1909832