### PR TITLE
Revert Set `security.sandbox.warn_unprivileged_namespaces` to `false`

### DIFF
--- a/src/lib/floorp/defaults/pref/flatpak-prefs.js
+++ b/src/lib/floorp/defaults/pref/flatpak-prefs.js
@@ -5,5 +5,3 @@ pref("enable.floorp.update", false);
 pref("enable.floorp.updater.latest", false);
 
 pref("accessibility.typeaheadfind.soundURL", "default");
-
-pref("security.sandbox.warn_unprivileged_namespaces", false);


### PR DESCRIPTION
Assuming this release now includes the upstream fix, this is no longer needed.