### PR TITLE
Update to 24.08 runtime, Add/Remove permissions

### DIFF
--- a/one.ablaze.floorp.appdata.xml
+++ b/one.ablaze.floorp.appdata.xml
@@ -56,8 +56,11 @@
   </screenshots>
   <content_rating type="oars-1.1"/>
   <releases>
-    <release version="11.18.1" date="2024-09-08">
+    <release version="11.18.1.1" date="2024-09-08">
       <description></description>
+    </release>
+    <release version="11.18.1" date="2024-09-08">
+      <description />
     </release>
     <release version="11.18.0" date="2024-09-02">
       <description/>

--- a/one.ablaze.floorp.yml
+++ b/one.ablaze.floorp.yml
@@ -74,18 +74,6 @@ modules:
       - /bin
       - /share/et
       - /share/examples
-  - name: libnotify
-    buildsystem: meson
-    config-opts:
-      - -Dtests=false
-      - -Dintrospection=disabled
-      - -Dman=false
-      - -Dgtk_doc=false
-      - -Ddocbook_docs=disabled
-    sources:
-      - type: archive
-        url: https://download.gnome.org/sources/libnotify/0.8/libnotify-0.8.3.tar.xz
-        sha256: ee8f3ef946156ad3406fdf45feedbdcd932dbd211ab4f16f75eba4f36fb2f6c0
   - name: sound-theme-freedesktop
     sources:
       - type: git

--- a/one.ablaze.floorp.yml
+++ b/one.ablaze.floorp.yml
@@ -1,7 +1,7 @@
 app-id: one.ablaze.floorp
 name: Floorp
 runtime: org.freedesktop.Platform
-runtime-version: 23.08
+runtime-version: 24.08
 sdk: org.freedesktop.Sdk
 add-extensions:
   org.freedesktop.Platform.ffmpeg-full:

--- a/one.ablaze.floorp.yml
+++ b/one.ablaze.floorp.yml
@@ -12,7 +12,6 @@ command: floorp
 finish-args:
   - --share=ipc
   - --share=network
-  - --env=GTK_PATH=/app/lib/gtkmodules
   - --socket=pulseaudio
   - --socket=wayland
   - --socket=fallback-x11
@@ -33,10 +32,7 @@ finish-args:
   - --talk-name=org.freedesktop.FileManager1
   - --system-talk-name=org.freedesktop.NetworkManager
   - --talk-name=org.a11y.Bus
-  - --talk-name=org.gnome.SessionManager
-  - --talk-name=org.freedesktop.ScreenSaver
   - --talk-name=org.gtk.vfs.*
-  - --talk-name=org.freedesktop.Notifications
   - --own-name=org.mpris.MediaPlayer2.firefox.*
   - --own-name=org.mozilla.floorp.*
 cleanup:

--- a/one.ablaze.floorp.yml
+++ b/one.ablaze.floorp.yml
@@ -6,7 +6,7 @@ sdk: org.freedesktop.Sdk
 add-extensions:
   org.freedesktop.Platform.ffmpeg-full:
     directory: lib/ffmpeg
-    version: 23.08
+    version: 24.08
     add-ld-path: .
 command: floorp
 finish-args:

--- a/one.ablaze.floorp.yml
+++ b/one.ablaze.floorp.yml
@@ -18,6 +18,7 @@ finish-args:
   - --socket=pcsc
   - --socket=cups
   - --persist=.floorp
+  - --env=DICPATH=/usr/share/hunspell
   - --filesystem=home/.local/share/applications:create
   - --filesystem=home/.local/share/icons:create
   - --filesystem=xdg-desktop


### PR DESCRIPTION
* Update to 24.08 runtime
* Remove libnotify, it is in the runtime, see: https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/blob/0aa0f24f891179f06c8312c28b514266b16d9541/NEWS.yml#L2322
* Remove unused permissions, see: [Bug 1871735](https://bugzilla.mozilla.org/show_bug.cgi?id=1871735), [Bug 1870968](https://bugzilla.mozilla.org/show_bug.cgi?id=1870968), [Bug 1863116](https://bugzilla.mozilla.org/show_bug.cgi?id=1863116)
* Add DICPATH env, see: [Bug 1881830](https://bugzilla.mozilla.org/show_bug.cgi?id=1881830)