### PR TITLE
Floorp 12 Testing

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,3 @@
 {
-  "only-arches": ["aarch64", "x86_64"]
+  "only-arches": ["x86_64"]
 }

--- a/one.ablaze.floorp.yml
+++ b/one.ablaze.floorp.yml
@@ -3,6 +3,7 @@ name: Floorp
 runtime: org.freedesktop.Platform
 runtime-version: 24.08
 sdk: org.freedesktop.Sdk
+base: org.mozilla.firefox.BaseApp
 add-extensions:
   org.freedesktop.Platform.ffmpeg-full:
     directory: lib/ffmpeg
@@ -17,6 +18,7 @@ finish-args:
   - --socket=fallback-x11
   - --socket=pcsc
   - --socket=cups
+  - --persist=.ablaze
   - --persist=.floorp
   - --env=DICPATH=/usr/share/hunspell
   - --filesystem=home/.local/share/applications:create
@@ -49,82 +51,6 @@ cleanup:
   - '*.la'
   - '*.a'
 modules:
-  - shared-modules/dbus-glib/dbus-glib.json
-  - shared-modules/libcanberra/libcanberra.json
-  - shared-modules/intltool/intltool-0.51.json
-  - name: kerberos
-    subdir: src
-    config-opts:
-      - --localstatedir=/var/lib
-      - --sbindir=${FLATPAK_DEST}/bin
-      - --disable-rpath
-      - --disable-static
-    post-install:
-      - install -Dm644 ../krb5.conf -t ${FLATPAK_DEST}/etc/
-    sources:
-      - type: archive
-        url: https://kerberos.org/dist/krb5/1.21/krb5-1.21.tar.gz
-        sha256: 69f8aaff85484832df67a4bbacd99b9259bd95aab8c651fbbe65cdc9620ea93b
-      - type: file
-        path: krb5.conf
-    cleanup:
-      - /bin
-      - /share/et
-      - /share/examples
-  - name: sound-theme-freedesktop
-    sources:
-      - type: git
-        url: https://salsa.debian.org/gnome-team/sound-theme-freedesktop.git
-        tag: upstream/0.8
-  - name: pcsc-lite
-    config-opts:
-      - --disable-libudev
-      - --disable-libsystemd
-      - --without-systemdsystemunitdir
-      - --disable-serial
-      - --disable-usb
-      - --disable-documentation
-      - --disable-polkit
-    post-install:
-      - rm /app/sbin/pcscd
-      - rmdir /app/sbin || true
-    sources:
-      - type: archive
-        url: https://salsa.debian.org/rousseau/PCSC/-/archive/2.0.3/PCSC-2.0.3.tar.bz2
-        sha256: 35ce63ff9f8fa34b67fbc791be08b3daba621263545e3d0fe1e480301f10a41d
-  - name: dotconf
-    cleanup:
-      - '*'
-    sources:
-      - type: archive
-        url: https://github.com/williamh/dotconf/archive/refs/tags/v1.3.tar.gz
-        sha256: 7f1ecf40de1ad002a065a321582ed34f8c14242309c3547ad59710ae3c805653
-      - type: script
-        commands:
-          - autoreconf -fiv
-        dest-filename: autogen.sh
-  - name: libspeechd
-    config-opts:
-      - --disable-python
-      - --with-systemdsystemunitdir=''
-      - --disable-rpath
-      - --disable-static
-      - --with-kali=no
-      - --with-baratinoo=no
-      - --with-ibmtts=no
-      - --with-voxin=no
-      - --without-oss
-    sources:
-      - type: archive
-        url: https://github.com/brailcom/speechd/releases/download/0.11.5/speech-dispatcher-0.11.5.tar.gz
-        sha256: 1ce4759ffabbaf1aeb433a5ec0739be0676e9bdfbae9444a7b3be1b2af3ec12b
-    cleanup:
-      - /bin
-      - /etc
-      - /libexec
-      - /lib/speech-dispatcher
-      - /share/sounds/speech-dispatcher
-      - /share/speech-dispatcher
   - name: floorp
     buildsystem: simple
     build-commands:

--- a/one.ablaze.floorp.yml
+++ b/one.ablaze.floorp.yml
@@ -57,8 +57,8 @@ modules:
     build-commands:
       - install -Dm644 one.ablaze.floorp.appdata.xml -t /app/share/metainfo/
       - mkdir -p /app/lib/ffmpeg
-      - mv floorp-*.tar.bz2 floorp.tar.bz2
-      - tar -xvf ./floorp.tar.bz2 -C /app/lib
+      - mv floorp-linux-amd64.tar.xz floorp.tar.xz
+      - tar -xvf ./floorp.tar.xz -C /app/lib
       - cp -r ./src/* /app/
       - chmod +x /app/bin/floorp
       - >

--- a/one.ablaze.floorp.yml
+++ b/one.ablaze.floorp.yml
@@ -78,8 +78,8 @@ modules:
       - type: file
         only-arches:
           - x86_64
-        url: https://github.com/Floorp-Projects/Floorp-12/releases/download/beta/floorp-linux-amd64.tar.xz
-        sha256: 93ecf77549422e62945f9d5972c6eb76d727889d47fa13da0ca61f8d8b675d19
+        url: https://github.com/Floorp-Projects/Floorp/releases/download/v12.0.0-rc/floorp-linux-amd64.tar.xz
+        sha256: a68a930e480339f59408f2b257d7e2fed055e734479ac19dd7ab1a6c8e52fdfa
 
       - type: file
         path: one.ablaze.floorp.appdata.xml

--- a/one.ablaze.floorp.yml
+++ b/one.ablaze.floorp.yml
@@ -151,26 +151,8 @@ modules:
       - type: file
         only-arches:
           - x86_64
-        url: https://github.com/Floorp-Projects/Floorp/releases/download/v11.25.0/floorp-11.25.0.linux-x86_64.tar.bz2
-        sha256: 44341f662a5cd990fd985d218baa96982a53e6e101c4551fc68c4b5c26845091
-        x-checker-data:
-          is-main-source: true
-          type: json
-          url: https://api.github.com/repos/Floorp-Projects/Floorp/releases/latest
-          version-query: .tag_name | sub("^v"; "")
-          url-query: '"https://github.com/Floorp-Projects/Floorp/releases/download/v"
-            + $version + "/floorp-" + $version + ".linux-x86_64.tar.bz2"'
-      - type: file
-        only-arches:
-          - aarch64
-        url: https://github.com/Floorp-Projects/Floorp/releases/download/v11.25.0/floorp-11.25.0.linux-aarch64.tar.bz2
-        sha256: 3da7d72f06c1369efa6425646ce2f3b12a6a03f164fda191c64078a1f6d11519
-        x-checker-data:
-          type: json
-          url: https://api.github.com/repos/Floorp-Projects/Floorp/releases/latest
-          version-query: .tag_name | sub("^v"; "")
-          url-query: '"https://github.com/Floorp-Projects/Floorp/releases/download/v"
-            + $version + "/floorp-" + $version + ".linux-aarch64.tar.bz2"'
+        url: https://github.com/Floorp-Projects/Floorp-12/releases/download/beta/floorp-linux-amd64.tar.xz
+        sha256: 77308e26539b709937fc46a8b5992c82d232da17d973ef23b447e104751383b4
 
       - type: file
         path: one.ablaze.floorp.appdata.xml

--- a/one.ablaze.floorp.yml
+++ b/one.ablaze.floorp.yml
@@ -79,7 +79,7 @@ modules:
         only-arches:
           - x86_64
         url: https://github.com/Floorp-Projects/Floorp-12/releases/download/beta/floorp-linux-amd64.tar.xz
-        sha256: c9eb07ee8453649a227de6e062ab0f49acdceb30ca1f127af72ae91e325df088
+        sha256: 93ecf77549422e62945f9d5972c6eb76d727889d47fa13da0ca61f8d8b675d19
 
       - type: file
         path: one.ablaze.floorp.appdata.xml

--- a/one.ablaze.floorp.yml
+++ b/one.ablaze.floorp.yml
@@ -4,6 +4,7 @@ runtime: org.freedesktop.Platform
 runtime-version: 24.08
 sdk: org.freedesktop.Sdk
 base: org.mozilla.firefox.BaseApp
+base-version: '24.08'
 add-extensions:
   org.freedesktop.Platform.ffmpeg-full:
     directory: lib/ffmpeg

--- a/one.ablaze.floorp.yml
+++ b/one.ablaze.floorp.yml
@@ -79,7 +79,7 @@ modules:
         only-arches:
           - x86_64
         url: https://github.com/Floorp-Projects/Floorp-12/releases/download/beta/floorp-linux-amd64.tar.xz
-        sha256: 77308e26539b709937fc46a8b5992c82d232da17d973ef23b447e104751383b4
+        sha256: c9eb07ee8453649a227de6e062ab0f49acdceb30ca1f127af72ae91e325df088
 
       - type: file
         path: one.ablaze.floorp.appdata.xml


### PR DESCRIPTION
Not sure how else to build this, so I'll just use a draft merge request since the changes will be infrequent anyways (this IS NOT putting Floorp on Flathub Beta).

This merge request's purpose is to prepare Flathub Floorp for the eventual release of Floorp 12, ensuring the Flatpak's ready to be compiled and pushed upon the release of Floorp 12.

This should also remain a draft in general as it regresses Floorp's compatibility due to Floorp 12's test builds not being for ARM, and removes the auto-PR stuff due to the usage of Floorp 12 links.

To be done: Edit ./src/bin/floorp to add a .floorp -> .ablaze/floorp transfer script before Floorp launches.
Branches: floorp-12-exp is experimentation, and floorp-12 is a separate branch for the purpose of PRing the fruits of exp's experimentation into main branch during the Floorp 12 release pull request when the time comes (if exp was pushed, there'd be conflicts from exp's temporary changes).