### PR TITLE
Fix system wide settings folder creation

### DIFF
--- a/one.ablaze.floorp.yml
+++ b/one.ablaze.floorp.yml
@@ -54,6 +54,7 @@ modules:
     build-commands:
       - install -Dm644 one.ablaze.floorp.appdata.xml -t /app/share/metainfo/
       - mkdir -p /app/lib/ffmpeg
+      - mkdir -p /app/etc/floorp
       - mv floorp-linux-*.tar.xz floorp.tar.xz
       - tar -xvf ./floorp.tar.xz -C /app/lib
       - cp -r ./src/* /app/


### PR DESCRIPTION
The commit 7a9154a35533e8d4982a21fac18379a57afe748b introduced ability to have system wide config. However the directory `/app/etc/floorp` has to be crated during build similar to `/app/lib/ffmpeg`. Without this line Floorp is failing with error message `bwrap: Can't mkdir /app/etc/floorp: Read-only file system`