### PR TITLE
Update runtime to 25.08

### DIFF
--- a/one.ablaze.floorp.yml
+++ b/one.ablaze.floorp.yml
@@ -1,14 +1,10 @@
 app-id: one.ablaze.floorp
 runtime: org.freedesktop.Platform
-runtime-version: 24.08
+runtime-version: 25.08
 sdk: org.freedesktop.Sdk
 base: org.mozilla.firefox.BaseApp
-base-version: '24.08'
+base-version: '25.08'
 add-extensions:
-  org.freedesktop.Platform.ffmpeg-full:
-    directory: lib/ffmpeg
-    version: 24.08
-    add-ld-path: .
   one.ablaze.floorp.systemconfig:
     directory: etc/floorp
     no-autodownload: true


### PR DESCRIPTION
Also, drop the ffmpeg extension 

> This is supposed to ship in Freedesktop SDK 25.08. The major change for app developers is that there is no longer any need to have something like 

Source: https://bbhtt.in/posts/closing-the-chapter-on-openh264/